### PR TITLE
Added Parceler support

### DIFF
--- a/icepick-processor/src/main/java/icepick/processor/AbsWriter.java
+++ b/icepick-processor/src/main/java/icepick/processor/AbsWriter.java
@@ -68,8 +68,11 @@ abstract class AbsWriter {
       case SERIALIZABLE:
         return "    target." + field.getName() + " = (" + field.getFieldType() +
             ") savedInstanceState.getSerializable(" + BASE_KEY + " + \"" + field.getName() + "\");\n";
+      case PARCEL:
+        return "    target." + field.getName() + " = org.parceler.Parceles.unwrap(" +
+                "savedInstanceState.getParcelable(" + BASE_KEY + " + \"" + field.getName() + "\"));\n";
       default:
-        return "    target." + field.getName() + " = " + "unwrap(" +
+        return "    target." + field.getName() + " = unwrap(" +
             "savedInstanceState.getParcelable(" + BASE_KEY + " + \"" + field.getName() + "\"));\n";
     }
   }
@@ -86,6 +89,9 @@ abstract class AbsWriter {
       case SERIALIZABLE:
         return "    outState.putSerializable(" + BASE_KEY + " + \""
             + field.getName() + "\", target." + field.getName() + ");\n";
+      case PARCEL:
+        return "    outState.putParcelable(" + BASE_KEY + " + \""
+                + field.getName() + "\", org.parceler.Parceles.wrap(target." + field.getName() + "));\n";
       default:
         return "    outState.putParcelable(" + BASE_KEY + " + \""
             + field.getName() + "\", wrap(target." + field.getName() + "));\n";

--- a/icepick-processor/src/main/java/icepick/processor/AnnotatedField.java
+++ b/icepick-processor/src/main/java/icepick/processor/AnnotatedField.java
@@ -8,6 +8,7 @@ class AnnotatedField {
   enum WrappingStrategy {
     SERIALIZABLE,
     PARCELABLE,
+    PARCEL,
     CUSTOM
   }
 

--- a/icepick-processor/src/main/java/icepick/processor/AnnotationsConverter.java
+++ b/icepick-processor/src/main/java/icepick/processor/AnnotationsConverter.java
@@ -7,6 +7,7 @@ import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
 import javax.annotation.processing.Messager;
+import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.Modifier;
 import javax.lang.model.element.TypeElement;
@@ -83,8 +84,23 @@ class AnnotationsConverter {
         return AnnotatedField.WrappingStrategy.SERIALIZABLE;
       }
 
+      if (isAnnotated(typeUtils.asElement(type), "org.parceler.Parcel")){
+        return AnnotatedField.WrappingStrategy.PARCEL;
+      }
+
       return AnnotatedField.WrappingStrategy.CUSTOM;
     }
+  }
+
+  private boolean isAnnotated(Element element, String annotationName) {
+    if (element != null) {
+      for (AnnotationMirror annotationMirror : element.getAnnotationMirrors()) {
+        if (annotationMirror.getAnnotationType().asElement().toString().equals(annotationName)) {
+          return true;
+        }
+      }
+    }
+    return false;
   }
 
   private class ToErasedEnclosingClass implements Function<AnnotatedField, TypeMirror> {

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -4,6 +4,8 @@ dependencies {
   compile 'joda-time:joda-time:2.3'
   compile 'com.github.frankiesardo:icepick:2.3.1'
   provided 'com.github.frankiesardo:icepick-processor:2.3.1'
+  compile 'org.parceler:parceler:0.2.6'
+  provided 'org.parceler:parceler-api:0.2.6'
 }
 
 android {

--- a/sample/src/main/java/com/github/frankiesardo/icepick/ExampleParcel.java
+++ b/sample/src/main/java/com/github/frankiesardo/icepick/ExampleParcel.java
@@ -1,0 +1,24 @@
+package com.github.frankiesardo.icepick;
+
+import org.parceler.Parcel;
+import org.parceler.ParcelConstructor;
+
+@Parcel
+public class ExampleParcel {
+  String name;
+  int age;
+
+  @ParcelConstructor
+  public ExampleParcel(String name, int age) {
+    this.name = name;
+    this.age = age;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public int getAge() {
+    return age;
+  }
+}

--- a/sample/src/main/java/com/github/frankiesardo/icepick/MainActivity.java
+++ b/sample/src/main/java/com/github/frankiesardo/icepick/MainActivity.java
@@ -12,6 +12,7 @@ public class MainActivity extends BaseActivity {
   @Icicle String message;
   @Icicle Bundle someUnusedExtras = new Bundle();
   @Icicle DateTime timestamp = DateTime.now();
+  @Icicle ExampleParcel exampleParcel;
 
   CustomView customView;
 


### PR DESCRIPTION
With just a couple additions Icepick can support Parceler. This means that Icepick can read beans annotated with `@Parcel` if the Parceler library is included and used.

Included are the necessary changes, examples and tests.

Forgive me if this doesn't work 100%, I was unable to get the Gradle build to execute.
