### PR TITLE
Fix ProGuard rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,8 +55,8 @@ If Proguard is enabled make sure you add these rules to your configuration:
 
 ```
 -dontwarn icepick.**
--keep class **$$State { *; }
--keepnames class * { @icepick.State *;}
+-keep class **$$Icepick { *; }
+-keepnames class * { @icepick.State *; }
 -keepclasseswithmembernames class * {
     @icepick.* <fields>;
 }


### PR DESCRIPTION
The generated class suffix is currently `$$Icepick`, not `$$State`. It was changed in f60b4b9 when `@Icicle` was renamed to `@State` but the generated classes went from `$$Icicle` to `$$Icepick`.