### PR TITLE
Custom setup strategy

### DIFF
--- a/icepick/src/icepick/Setuper.java
+++ b/icepick/src/icepick/Setuper.java
@@ -1,0 +1,6 @@
+package icepick;
+
+public interface Setuper<T, F> {
+
+    void setup(T target, F value);
+}

--- a/icepick/src/icepick/State.java
+++ b/icepick/src/icepick/State.java
@@ -8,5 +8,6 @@ import java.lang.annotation.Target;
 @Target(ElementType.FIELD)
 @Retention(RetentionPolicy.CLASS)
 public @interface State {
-    Class<? extends Bundler> value() default Bundler.class;
+    Class<? extends Bundler> bundler() default Bundler.class;
+    Class<? extends Setuper> setuper() default null;
 }

--- a/sample/app/src/main/java/com/github/frankiesardo/icepick/MainActivity.java
+++ b/sample/app/src/main/java/com/github/frankiesardo/icepick/MainActivity.java
@@ -9,7 +9,8 @@ import icepick.State;
 
 public class MainActivity extends BaseActivity {
 
-  @State(MyBundler.class) String message;
+  @State(bundler = MyBundler.class, setuper = MySetuper.class)
+  String message;
 
   CustomView customView;
 

--- a/sample/app/src/main/java/com/github/frankiesardo/icepick/MySetuper.java
+++ b/sample/app/src/main/java/com/github/frankiesardo/icepick/MySetuper.java
@@ -1,0 +1,12 @@
+package com.github.frankiesardo.icepick;
+
+import icepick.Setuper;
+
+class MySetuper implements Setuper<MainActivity, String> {
+    @Override
+    public void setup(MainActivity target, String value) {
+        if (value != null) {
+            target.message = value;
+        }
+    }
+}


### PR DESCRIPTION
Add functionality for adding custom strategy for restoring some specific fields.
It can be very useful when:
- You wanna add nontrivial logic for new and old value. (e.g. while view was in recreating process some changes happened in presenter, and you do not want lose them)
- With Kotlin lateinit fields (e.g. instance state has been saved before lateinit var has been initialised and then you don't want set null in lateinit var after restoring state)